### PR TITLE
chore: remove forge-std

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate


### PR DESCRIPTION
I want to remove the independently managed `forge-std` package since it just causes more confusion with our root `forge-std` dependency and the other `forge-std` sub-dependency within `forge-safe`.